### PR TITLE
[skip-ci] fix(tailwind): mistake in publishing package

### DIFF
--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@privyid/tailwind-preset",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "yarn@3.2.1",
   "main": "./index.js",
   "peerDependencies": {


### PR DESCRIPTION
It should be use `yarn npm publish` instead of `npm publish`
