### PR TITLE
fix(dropdown): stop downdrop to prevent others tab keyup

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -210,23 +210,25 @@ export default defineComponent({
     })
 
     onKeyStroke(['ArrowUp'], (event) => {
-      event.preventDefault()
+      if (isOpen.value) {
+        event.preventDefault()
 
-      if (isOpen.value)
         prevFocus()
+      }
     })
 
     onKeyStroke(['ArrowDown'], (event) => {
-      event.preventDefault()
+      if (isOpen.value) {
+        event.preventDefault()
 
-      if (isOpen.value)
         nextFocus()
+      }
     })
 
     onKeyStroke(['Tab'], (event) => {
-      event.preventDefault()
-
       if (isOpen.value) {
+        event.preventDefault()
+
         if (event.shiftKey)
           prevFocus()
         else

--- a/src/components/dropdown/DropdownItem.vue
+++ b/src/components/dropdown/DropdownItem.vue
@@ -14,7 +14,9 @@
 
 <script lang="ts">
 import {
-  defineComponent, inject, computed,
+  defineComponent,
+  inject,
+  computed,
 } from 'vue-demi'
 import { DROPDOWN_CONTEXT } from '.'
 import { TagVariant } from '../button'
@@ -64,7 +66,9 @@ export default defineComponent({
     })
 
     return {
-      handleOnClick, classNames, tagName,
+      handleOnClick,
+      classNames,
+      tagName,
     }
   },
 })

--- a/src/components/form-group/index.md
+++ b/src/components/form-group/index.md
@@ -6,7 +6,6 @@ description: Form label, caption, and other stuff.
 <script setup>
   import pFormGroup from './FormGroup.vue'
   import pInput from '../input/Input.vue'
-  import pCheckbox from '../checkbox/Checkbox.vue'
 </script>
 
 # Form Group

--- a/src/components/form-group/kitchensink.md
+++ b/src/components/form-group/kitchensink.md
@@ -1,0 +1,25 @@
+<script setup>
+  import pFormGroup from './FormGroup.vue'
+  import pInput from '../input/Input.vue'
+  import pCheckbox from '../checkbox/Checkbox.vue'
+</script>
+
+# Testing
+
+<p-form-group label="First Name">
+  <p-input />
+</p-form-group>
+
+<p-form-group label="Last Name">
+  <p-input />
+</p-form-group>
+
+<p-form-group label="Email">
+  <p-input />
+</p-form-group>
+
+<p-form-group label="Anumas">
+  <p-input />
+</p-form-group>
+
+<p-checkbox>Anu</p-checkbox>


### PR DESCRIPTION
Fix issue when input and dropdown use together, pressing 'Tab' wouldn't not work even dropdown not used (opened)