### PR TITLE
fix/reorganize-zindex-of-components

### DIFF
--- a/packages/tailwind-preset/index.js
+++ b/packages/tailwind-preset/index.js
@@ -304,7 +304,18 @@ module.exports = {
         },
       },
       ringColor: ({ theme }) => ({ ...theme('borderColor') }),
-      zIndex   : { 1: 1 },
+      zIndex   : {
+        1      : 1,
+        fixed  : 1040,
+        modal  : 1050,
+        overlay: 1060,
+        tooltip: 1070,
+        tour   : {
+          DEFAULT : 1085,
+          backdrop: 1080,
+        },
+        toast: 1090,
+      },
     },
   },
 }

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -191,7 +191,7 @@ export default defineComponent({
   --p-modal-size-lg: 800px;
   --p-modal-size-md: 600px;
   --p-modal-size-sm: 400px;
-  --p-modal-z-index: 1060;
+  --p-modal-z-index: theme(zIndex.modal);
   --p-modal-dismiss-z-index: calc(var(--p-modal-z-index) + 1);
 
   /**

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -60,6 +60,7 @@ description: ase component for modal dialog.
 > Base component for modal dialog.
 
 ## Usage
+Modal are using `z-modal` for z-index value. It posible to change z-index value using CSS variable `--p-modal-z-index`. But don't forget to see the all [z-index](/foundation/variables/#z-index) variant for layer-ordering component.
 
 ### Simple Usage
 

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -95,7 +95,7 @@ export default defineComponent({
 
 <style lang="postcss">
 .navbar {
-  --p-navbar-z-index: 1030;
+  --p-navbar-z-index: theme(zIndex.fixed);
 
   @apply bg-default relative p-3 flex items-center flex-wrap transition-shadow duration-150 ease-in-out;
   @apply dark:bg-dark-default;

--- a/src/components/navbar/index.md
+++ b/src/components/navbar/index.md
@@ -37,7 +37,7 @@ description: Base dashboard navbar.
     @apply block relative;
 
     &--fixed {
-      @apply h-36 overflow-hidden;
+      @apply h-40 overflow-hidden;
 
       .navbar--fixed {
         @apply absolute z-10;
@@ -124,6 +124,7 @@ Navbar brand is used for company, product, or project name. You can add permalin
 ```
 
 ## Fixed Navbar
+Fixed navbar are using `z-fixed` for z-index value. It posible to change z-index value using CSS variable `--p-navbar-z-index`. But don't forget to see the all [z-index](/foundation/variables/#z-index) variant for layer-ordering component.
 <preview class="flex-grow preview--fixed">
   <p-navbar fixed>
     <p-navbar-brand>

--- a/src/components/overlay/Overlay.vue
+++ b/src/components/overlay/Overlay.vue
@@ -57,7 +57,9 @@ export default defineComponent({
 }
 
 .overlay {
-  @apply fixed top-0 left-0 right-0 bottom-0 w-screen h-screen z-50 bg-inverse/30 flex items-center justify-center select-none will-change-[transform,opacity];
+  --p-overlay-z-index: theme(zIndex.overlay);
+
+  @apply z-[var(--p-overlay-z-index)] fixed top-0 left-0 right-0 bottom-0 w-screen h-screen bg-inverse/30 flex items-center justify-center select-none will-change-[transform,opacity];
   @apply dark:bg-dark-inverse/30;
 
   &__icon {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -96,6 +96,7 @@ export default defineComponent({
 .sidebar {
   --p-sidebar-size-narrow: 60px;
   --p-sidebar-size-wide: 230px;
+  --p-sidebar-z-index: theme(zIndex.fixed);
 
   @apply bg-default px-2 py-4;
   @apply dark:bg-dark-default;
@@ -121,7 +122,7 @@ export default defineComponent({
   * Fixed sidebar
   */
   &&--fixed {
-    @apply fixed top-0 h-full shadow-lg overflow-y-auto;
+    @apply fixed z-[var(--p-sidebar-z-index)] top-0 h-full shadow-lg overflow-y-auto;
 
     &:not(.sidebar--right) {
       @apply left-0;

--- a/src/components/sidebar/index.md
+++ b/src/components/sidebar/index.md
@@ -73,6 +73,7 @@ description: Base dashboard sidebar menu.
 ```
 
 ### Fixed Sidebar
+Fixed sidebar are using z-fixed for z-index value. It posible to change z-index value using CSS variable `--p-sidebar-z-index`. But don't forget to see the all [z-index](/foundation/variables/#z-index) variant for layer-ordering component.
 <preview>
   <p-sidebar fixed>
     <p-sidebar-brand>

--- a/src/components/toast/Toast.vue
+++ b/src/components/toast/Toast.vue
@@ -122,6 +122,8 @@ export default defineComponent({
   * global style
   * of toast
   */
+  --p-toast-z-index: theme(zIndex.toast);
+
   @apply flex shadow-xl rounded w-72 md:w-96 overflow-hidden;
 
   .toast__icon,

--- a/src/components/toast/ToastContainer.vue
+++ b/src/components/toast/ToastContainer.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <style lang="postcss">
 .toast-container {
-  @apply fixed top-0 right-0 z-40 flex flex-col space-y-2 max-h-screen overflow-visible;
+  @apply z-[var(--p-toast-z-index)] fixed top-0 right-0 flex flex-col space-y-2 max-h-screen overflow-visible;
 }
 
 .toast {

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -127,7 +127,9 @@ export default defineComponent({
 
 <style lang="postcss">
 .tooltip {
-  @apply px-4 py-3 rounded text-xs inline-block z-30 absolute drop-shadow-sm;
+  --p-tooltip-z-index: theme(zIndex.tooltip);
+
+  @apply z-[var(--p-tooltip-z-index)] px-4 py-3 rounded text-xs inline-block absolute drop-shadow-sm;
 
   &__arrow {
     @apply absolute after:w-4 after:h-4 after:block after:rounded-[3px] after:rotate-45 after:left-0 after:content-[''] after:z-0;

--- a/src/components/tour/Tour.vue
+++ b/src/components/tour/Tour.vue
@@ -106,6 +106,9 @@ export default defineComponent({
 
 <style lang="postcss">
 .tour {
+  --p-tour-z-index: theme(zIndex.tour.DEFAULT);
+  --p-tour-backdrop-z-index: theme(zIndex.tour.backdrop);
+
   & > &__dialog {
     @apply absolute top-0 left-0;
   }

--- a/src/components/tour/TourDialog.vue
+++ b/src/components/tour/TourDialog.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 <style lang="postcss">
 .tour {
   &__dialog {
-    @apply rounded bg-inverse w-full max-w-xs z-[100] overflow-hidden relative shadow-sm;
+    @apply z-[var(--p-tour-z-index)] rounded bg-inverse w-full max-w-xs overflow-hidden relative shadow-sm;
     @apply dark:bg-dark-inverse;
   }
 

--- a/src/components/tour/TourHighlight.vue
+++ b/src/components/tour/TourHighlight.vue
@@ -53,11 +53,11 @@ export default defineComponent({
 <style lang="postcss">
 .tour {
   &__backdrop {
-    @apply fixed inset-0 overflow-hidden w-full h-full z-[100];
+    @apply fixed inset-0 overflow-hidden w-full h-full z-[var(--p-tour-backdrop-z-index)];
   }
 
   &__highlight {
-    @apply absolute shadow-mask cursor-pointer rounded-tn;
+    @apply z-[var(--p-tour-z-index)] absolute shadow-mask cursor-pointer rounded-tn;
   }
 }
 </style>

--- a/src/foundation/variables/index.md
+++ b/src/foundation/variables/index.md
@@ -290,3 +290,20 @@ Tooltip use shadow `sm`
 
 ### Tour
 Tour is using shadow `sm`
+
+## Z-Index
+Some components that have fixed and absolute positions are given z-index values to sort their layer hierarchies.
+
+<div class="table-list w-full">
+
+| Name              |   Value     | Component            |
+|-------------------|-------------|----------------------|
+| z-fixed           | 1040        | Navbar & Sidebar     |
+| z-modal           | 1050        | Modal                |
+| z-overlay         | 1060        | Overlay              |
+| z-tooltip         | 1070        | Tooltip              |
+| z-tour-backdrop   | 1080        | Tour backdrop        |
+| z-tour            | 1085        | Tour                 |
+| z-toast           | 1090        | Toast                |
+
+</div>


### PR DESCRIPTION
add hierarchy of component layer
- z-fixed 1040
- z-modal 1050
- z-overlay 1060
- z-tooltip 1070
- z-tour-backdrop 1080
- z-tour 1085
- z-toast 1090

Customizeable z-index by CSS variable (navbar, sidebar, modal)
Create z-index documentation in foundation > variables
Update z-index of tailwind-preset