### PR TITLE
fix: change default value to undefined

### DIFF
--- a/src/components/input-pin/InputPin.vue
+++ b/src/components/input-pin/InputPin.vue
@@ -44,7 +44,7 @@ export default defineComponent({
   props       : {
     modelValue: {
       type   : String,
-      default: '',
+      default: undefined,
     },
     length: {
       type   : [Number, String],
@@ -71,7 +71,7 @@ export default defineComponent({
   setup (props, { emit }) {
     const root       = templateRef<HTMLDivElement>('root')
     const num        = useToNumber(toRef(props, 'length'))
-    const localModel = ref<string[]>([...props.modelValue.padEnd(num.value)].slice(0, num.value))
+    const localModel = ref<string[]>([...(props.modelValue?.padEnd(num.value) ?? '')].slice(0, num.value))
 
     const classNames = computed(() => {
       const result: string[] = []
@@ -92,7 +92,7 @@ export default defineComponent({
 
     const model = computed<string[]>({
       get () {
-        return [...props.modelValue.padEnd(num.value)].slice(0, num.value)
+        return [...(props.modelValue?.padEnd(num.value) ?? '')].slice(0, num.value)
       },
       set (value: string[]) {
         const text = value.map((val) => val || ' ').join('').trimEnd()

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -46,7 +46,7 @@ export default defineComponent({
   props       : {
     modelValue: {
       type   : [String, Number],
-      default: '',
+      default: undefined,
     },
     size: {
       type   : String as PropType<SizeVariant>,

--- a/src/components/textarea/Textarea.vue
+++ b/src/components/textarea/Textarea.vue
@@ -39,7 +39,7 @@ export default defineComponent({
   props       : {
     modelValue: {
       type   : String,
-      default: '',
+      default: undefined,
     },
     placeholder: {
       type   : String,


### PR DESCRIPTION
Hi creator,

I hope you're doing well! I've made some changes to the component and wanted to bring your attention to one specific modification. I noticed that the default value in the component was set to an empty string, which caused immediate validation when using library form validation. To handle this, I have updated the default value to be undefined. This adjustment ensures that empty string values are not immediately validated, resolving the issue.

Please review the changes at your convenience and let me know if you have any feedback or suggestions. I believe this modification will enhance the behavior of the component, particularly when it comes to form validation. Thank you for your time and consideration!

Best regards,
Rendy