### PR TITLE
fix(form-label): change text label from default to subtle

### DIFF
--- a/src/components/form-group/FormGroup.vue
+++ b/src/components/form-group/FormGroup.vue
@@ -85,8 +85,8 @@ export default defineComponent({
   @apply flex flex-col mb-4;
 
   &__label {
-    @apply font-bold text-xs mb-2 relative text-default;
-    @apply dark:text-dark-default;
+    @apply font-bold text-xs mb-2 relative text-subtle;
+    @apply dark:text-dark-subtle;
 
     > sup {
       @apply text-danger;

--- a/src/components/text/Text.vue
+++ b/src/components/text/Text.vue
@@ -183,10 +183,12 @@ export default defineComponent({
   * Form Label Style
   */
   &--formlabel {
-    @apply font-medium text-sm tracking-wide;
+    @apply font-medium text-sm tracking-wide text-subtle;
+    @apply dark:text-dark-subtle;
   }
   &--formlabel2 {
-    @apply font-medium text-xs leading-tightest;
+    @apply font-medium text-xs leading-tightest text-subtle;
+    @apply dark:text-dark-subtle;
   }
 
   /**


### PR DESCRIPTION
- change text-label color from fg/default to fg/subtle in form-group and freetext
[624](https://github.com/privy-open-source/design-system/issues/624)