### PR TITLE
fix(pin-input): fix inconsistent `deleteContentBackward` on safari

### DIFF
--- a/src/components/datepicker/Datepicker.spec.ts
+++ b/src/components/datepicker/Datepicker.spec.ts
@@ -264,4 +264,18 @@ it('should modify v-model:start and v-model:end when using props `range`', async
   expect(end.value.toISOString()).toBe(expected[1].toISOString())
 
   expect(input).toHaveValue('01/01/2022 - 08/01/2022')
+
+  start.value = undefined
+  end.value   = undefined
+
+  await nextTick()
+
+  expect(input).toHaveValue('')
+
+  start.value = new Date(2023, 0, 1)
+  end.value   = new Date(2023, 1, 1)
+
+  await nextTick()
+
+  expect(input).toHaveValue('01/01/2023 - 01/02/2023')
 })

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -15,6 +15,7 @@
         :placeholder="placeholder"
         :disabled="disabled"
         :error="error"
+        :size="size"
         readonly
         @focus="onFocus">
         <template #append>
@@ -57,6 +58,7 @@ import {
 import { CalendarMode } from '../calendar/adapter/adapter'
 import { useVModel } from '../input'
 import IconCalendar from '@privyid/persona-icon/vue/calendar/16.vue'
+import { SizeVariant } from '../button'
 
 export default defineComponent({
   components: {
@@ -69,6 +71,10 @@ export default defineComponent({
     modelValue: {
       type   : [Date, Array] as PropType<Date | [Date, Date]>,
       default: undefined,
+    },
+    size: {
+      type   : String as PropType<SizeVariant>,
+      default: 'md',
     },
     start: {
       type   : Date,

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -54,6 +54,7 @@ import {
   defineComponent,
   PropType,
   ref,
+  watch,
 } from 'vue-demi'
 import { CalendarMode } from '../calendar/adapter/adapter'
 import { useVModel } from '../input'
@@ -144,12 +145,25 @@ export default defineComponent({
     const isOpen = ref(false)
 
     const value = computed(() => {
-      if (props.range && Array.isArray(model.value))
-        return `${formatDate(model.value[0], props.format)} - ${formatDate(model.value[1], props.format)}`
+      const dates = Array.isArray(model.value)
+        ? model.value
+        : [model.value]
 
-      return isDate(model.value)
-        ? formatDate(model.value as Date, props.format)
-        : ''
+      return dates.map((date) => {
+        return isDate(date)
+          ? formatDate(date as Date, props.format)
+          : ''
+      }).filter(Boolean).join(' - ')
+    })
+
+    watch(() => props.start, (start) => {
+      if (Array.isArray(model.value))
+        model.value[0] = start
+    })
+
+    watch(() => props.end, (end) => {
+      if (Array.isArray(model.value))
+        model.value[1] = end
     })
 
     const classNames = computed(() => {

--- a/src/components/datepicker/index.md
+++ b/src/components/datepicker/index.md
@@ -38,6 +38,25 @@ description: Base button component
 </template>
 ```
 
+## Sizing
+Datepicker has 4 variants size: `xs`, `sm`, `md`, `lg`, default is `md`.
+
+<preview class="flex-col space-y-3">
+  <p-datepicker size="xs" />
+  <p-datepicker size="sm" />
+  <p-datepicker size="md" />
+  <p-datepicker size="lg" />
+</preview>
+
+```vue
+<template>
+  <p-datepicker size="xs" />
+  <p-datepicker size="sm" />
+  <p-datepicker size="md" />
+  <p-datepicker size="lg" />
+</template>
+```
+
 ## Placeholder
 
 You can set input placeholder via `placeholder` props
@@ -265,22 +284,23 @@ You can specific binding the value using `v-model:start` or `v-model:end`
 
 ### Props
 
-| Props         |   Type    |   Default    | Description                                        |
-|---------------|:---------:|:------------:|----------------------------------------------------|
-| `modelValue`  |  `Date`   |     `-`      | `v-model` value                                    |
-| `start`       |  `Date`   |     `-`      | `v-model:start` value                              |
-| `end`         |  `Date`   |     `-`      | `v-model:end` value                                |
-| `placeholder` | `String`  |     `-`      | Input placeholder                                  |
-| `format`      | `String`  | `dd/MM/yyyy` | Date format                                        |
-| `disabled`    | `Boolean` |   `false`    | Disabled state                                     |
-| `readonly`    | `Boolean` |   `false`    | Readonly state                                     |
-| `error`       | `Boolean` |   `false`    | Error state                                        |
-| `mode`        | `String`  |     `-`      | Calendar mode valid value: `date`, `month`, `year` |
-| `min`         |  `Date`   |     `-`      | Minimum date can be selected                       |
-| `max`         |  `Date`   |     `-`      | Maximum date can be selected                       |
-| `range`       | `Boolean` |   `false`    | Enable range picker mode                           |
-| `minRange`    | `String`  |     `-`      | Minimum range date should be selected              |
-| `maxRange`    | `String`  |     `-`      | Maximum range date should be selected              |
+| Props         |   Type    |   Default    | Description                                             |
+|---------------|:---------:|:------------:|---------------------------------------------------------|
+| `modelValue`  |  `Date`   |     `-`      | `v-model` value                                         |
+| `size`        | `String`  |     `md`     | Input size variant, valid value: `xs`, `sm`, `md`, `lg` |
+| `start`       |  `Date`   |     `-`      | `v-model:start` value                                   |
+| `end`         |  `Date`   |     `-`      | `v-model:end` value                                     |
+| `placeholder` | `String`  |     `-`      | Input placeholder                                       |
+| `format`      | `String`  | `dd/MM/yyyy` | Date format                                             |
+| `disabled`    | `Boolean` |   `false`    | Disabled state                                          |
+| `readonly`    | `Boolean` |   `false`    | Readonly state                                          |
+| `error`       | `Boolean` |   `false`    | Error state                                             |
+| `mode`        | `String`  |     `-`      | Calendar mode valid value: `date`, `month`, `year`      |
+| `min`         |  `Date`   |     `-`      | Minimum date can be selected                            |
+| `max`         |  `Date`   |     `-`      | Maximum date can be selected                            |
+| `range`       | `Boolean` |   `false`    | Enable range picker mode                                |
+| `minRange`    | `String`  |     `-`      | Minimum range date should be selected                   |
+| `maxRange`    | `String`  |     `-`      | Maximum range date should be selected                   |
 
 ### Slots
 

--- a/src/components/input-pin/InputPin.spec.ts
+++ b/src/components/input-pin/InputPin.spec.ts
@@ -144,9 +144,8 @@ it('should back to previous focus if delete the value', async () => {
   })
 
   const inputs = screen.queryAllByTestId('input')
-  const user   = userEvent.setup()
 
-  await user.clear(inputs.at(2))
+  await fireEvent.keyDown(inputs.at(2), { key: 'Backspace' })
 
   expect(prevFocus).toBeCalled()
 })

--- a/src/components/input-pin/InputPin.vue
+++ b/src/components/input-pin/InputPin.vue
@@ -141,11 +141,16 @@ export default defineComponent({
     }
 
     function onKeyDown (event: KeyboardEvent) {
-      if (event.key === 'Backspace') {
-        event.preventDefault()
-        event.stopPropagation()
+      const target = event.target as HTMLInputElement
 
-        ;(event.target as HTMLInputElement).dispatchEvent(new InputEvent('beforeinput', { inputType: 'deleteContentBackward' }))
+      if (target.value && [...event.key].length === 1 && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault()
+
+        target.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertText', data: event.key }))
+      } else if (event.key === 'Backspace') {
+        event.preventDefault()
+
+        target.dispatchEvent(new InputEvent('beforeinput', { inputType: 'deleteContentBackward' }))
       }
     }
 

--- a/src/components/input-pin/InputPin.vue
+++ b/src/components/input-pin/InputPin.vue
@@ -15,6 +15,7 @@
       :readonly="readonly"
       :disabled="disabled"
       :error="error"
+      @keydown="onKeyDown($event)"
       @beforeinput.prevent="setValue(i - 1, $event)"
       @keyup.left.stop.prevent="prevFocus"
       @keyup.right.stop.prevent="nextFocus" />
@@ -132,9 +133,19 @@ export default defineComponent({
         if (root.value) {
           if (event.inputType === 'deleteContentBackward')
             prevFocus()
-          else
+
+          if (event.inputType === 'insertText')
             nextFocus()
         }
+      }
+    }
+
+    function onKeyDown (event: KeyboardEvent) {
+      if (event.key === 'Backspace') {
+        event.preventDefault()
+        event.stopPropagation()
+
+        ;(event.target as HTMLInputElement).dispatchEvent(new InputEvent('beforeinput', { inputType: 'deleteContentBackward' }))
       }
     }
 
@@ -146,6 +157,7 @@ export default defineComponent({
       setValue,
       nextFocus,
       prevFocus,
+      onKeyDown,
     }
   },
 })


### PR DESCRIPTION
This fix issue event onbeforeinput on Safari, which not triggered `deleteContentBackward` when input was empty.