### PR TITLE
fix(select): clickable caret icon to toggle the dropdown

### DIFF
--- a/src/components/select/Select.spec.ts
+++ b/src/components/select/Select.spec.ts
@@ -331,3 +331,16 @@ it('should be toggle dropdown via `caret` slot-scope function', async () => {
 
   expect(select).not.toHaveClass('select--open')
 })
+
+it('should hide caret icon if props `no-caret` is provided', () => {
+  const screen = render({
+    components: { Select },
+    template  : `
+      <Select no-caret />
+    `,
+  })
+
+  const caret = screen.queryByTestId('select-caret-icon')
+
+  expect(caret).not.toBeInTheDocument()
+})

--- a/src/components/select/Select.spec.ts
+++ b/src/components/select/Select.spec.ts
@@ -275,3 +275,59 @@ it('should have style error if `error` prop was provided', () => {
 
   expect(select).toHaveClass('select--error', 'state--error')
 })
+
+it('should be toggle dropdown if caret icon is clicked', async () => {
+  const screen = render({
+    components: { Select },
+    template  : `
+      <Select />
+    `,
+  })
+
+  const select = screen.getByTestId('select')
+
+  expect(select).toBeInTheDocument()
+  expect(select).not.toHaveClass('select--open')
+
+  const caretIcon = screen.queryByTestId('select-caret-icon')
+
+  await fireEvent.click(caretIcon)
+  await nextTick()
+
+  expect(select).toHaveClass('select--open')
+
+  await fireEvent.click(caretIcon)
+  await nextTick()
+
+  expect(select).not.toHaveClass('select--open')
+})
+
+it('should be toggle dropdown via `caret` slot-scope function', async () => {
+  const screen = render({
+    components: { Select },
+    template  : `
+      <Select>
+        <template #caret="{ toggle }">
+          <div @click="toggle">Toggle</div>
+        </template>
+      </Select>
+    `,
+  })
+
+  const select = screen.getByTestId('select')
+
+  expect(select).toBeInTheDocument()
+  expect(select).not.toHaveClass('select--open')
+
+  const toggle = screen.queryByText('Toggle')
+
+  await fireEvent.click(toggle)
+  await nextTick()
+
+  expect(select).toHaveClass('select--open')
+
+  await fireEvent.click(toggle)
+  await nextTick()
+
+  expect(select).not.toHaveClass('select--open')
+})

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -16,7 +16,9 @@
         :disabled="disabled"
         :readonly="readonly"
         @focus="onFocus">
-        <template #append>
+        <template
+          v-if="!noCaret"
+          #append>
           <slot
             name="caret"
             :is-open="isOpen"
@@ -168,6 +170,10 @@ export default defineComponent({
     size: {
       type   : String as PropType<SizeVariant>,
       default: 'md',
+    },
+    noCaret: {
+      type   : Boolean,
+      default: false,
     },
   },
   models: {

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -17,7 +17,15 @@
         :readonly="readonly"
         @focus="onFocus">
         <template #append>
-          <IconArrow class="select__caret" />
+          <slot
+            name="caret"
+            :is-open="isOpen"
+            :toggle="toggleOpen">
+            <IconArrow
+              class="select__caret"
+              data-testid="select-caret-icon"
+              @click="toggleOpen" />
+          </slot>
         </template>
       </p-input>
     </template>
@@ -188,6 +196,10 @@ export default defineComponent({
     const items      = props.adapter.setup(context)
     const localModel = ref<SelectItem>(findSelected(items.value, props.modelValue))
 
+    const toggleOpen = () => {
+      isOpen.value = !isOpen.value
+    }
+
     const classNames = computed(() => {
       const result: string[] = []
 
@@ -265,6 +277,7 @@ export default defineComponent({
       isLoading,
       search,
       items,
+      toggleOpen,
       select,
       onFocus,
       isSelected,
@@ -286,8 +299,9 @@ export default defineComponent({
   }
 
   &__caret {
-    @apply transition-transform duration-150 text-subtle pointer-events-none;
+    @apply transition-transform duration-150 text-subtle;
     @apply dark:text-dark-subtle;
+    @apply cursor-pointer;
   }
 
   &__option {

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -410,11 +410,12 @@ If you want to make custom option with slot, you can use `option` with scoped sl
 
 ### Slots
 
-| Name      | Description                               |
-|-----------|-------------------------------------------|
-| `empty`   | Content when option is empty or not found |
-| `loading` | Content when loading                      |
-| `option`  | Content to place in Option Items          |
+| Name      | Description                                    |
+|-----------|------------------------------------------------|
+| `empty`   | Content when option is empty or not found      |
+| `loading` | Content when loading                           |
+| `option`  | Content to place in Option Items               |
+| `caret`   | Element for opening and closing the dropdown   |
 
 ### Events
 

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -6,6 +6,7 @@ description: Base form input.
 <script setup>
   import pSelect from "./Select.vue"
   import pAvatar from "../avatar/Avatar.vue"
+  import PiCaretDown16 from '@privyid/persona-icon/vue/caret-down/16.vue'
   import FuzzyAdapter from "../select/adapter/fuzzy-adapter"
   import defineAsyncAdapter from "./adapter/async-adapter"
   import { ref } from "vue-demi"
@@ -391,6 +392,56 @@ If you want to make custom option with slot, you can use `option` with scoped sl
   ])
 </script>
 ```
+
+## Caret
+
+### Custom Caret Icon
+
+By using the `caret` slot-scope, you can define your own custom icon for the caret, giving you the flexibility to choose a different icon or style that suits your design or preference.
+
+<preview>
+  <p-select :options="optionsA">
+    <template #caret="{ isOpen, toggle }">
+      <pi-caret-down-16 @click="toggle" />
+    </template>
+  </p-select>
+</preview>
+
+```vue
+<template>
+  <p-select :options="optionsA">
+    <template #caret="{ isOpen, toggle }">
+      <pi-caret-down-16 @click="toggle" />
+    </template>
+  </p-select>
+</template>
+
+<script setup>
+  import PiCaretDown16 from '@privyid/persona-icon/vue/caret-down/16.vue'
+
+  const options = ref(['Apple', 'Banana', 'Grape'])
+</script>
+```
+
+### Hide Caret
+
+When you set the `no-caret` prop to true, it will hide the caret icon, and users won't see it in the component.
+
+<preview>
+  <p-select :options="optionsA" no-caret />
+</preview>
+
+```vue
+<template>
+  <p-select :options="optionsA" />
+</template>
+
+<script setup>
+  const options = ref(['Apple', 'Banana', 'Grape'])
+</script>
+```
+
+
 ## API
 
 ### Props
@@ -407,6 +458,7 @@ If you want to make custom option with slot, you can use `option` with scoped sl
 | `adapter`     | `Adapter` | `BaseAdapter` | Adapter for loading option's items |
 | `modelValue`  |   `Any`   |      `-`      | `v-model` value                    |
 | `selected`    | `Object`  |      `-`      | `v-model:selected` value           |
+| `no-caret`    | `Boolean` |    `false`    | Hide caret icon                    |
 
 ### Slots
 


### PR DESCRIPTION
Fix and Enhancement: Toggle Dropdown and Custom Caret Icon

This PR addresses an issue and introduces an enhancement to the Select Dropdown component.

Fix:
- Resolved a bug where the dropdown did not toggle when clicking the caret icon.

Enhancement:
- Added the ability to customize the caret icon using the new "caret" slot scope. Developers can now easily replace the default caret icon with their own custom icon.

Changes:
- Modified the behavior of the caret icon to toggle the dropdown when clicked.
- Added a new "caret" slot to the Select Dropdown component to provide customization options for the caret icon.

This enhancement improves the user experience by allowing users to toggle the dropdown not only by clicking on the select element but also by clicking on the caret icon. Furthermore, it empowers developers to customize the appearance of the caret icon to better match their application's design.