### PR TITLE
fix: input pin readonly state issue

### DIFF
--- a/src/components/input-pin/InputPin.spec.ts
+++ b/src/components/input-pin/InputPin.spec.ts
@@ -149,3 +149,59 @@ it('should back to previous focus if delete the value', async () => {
 
   expect(prevFocus).toBeCalled()
 })
+
+it('should have readonly attribute if prop readonly was provided', async () => {
+  const screen = render({
+    components: { InputPin },
+    template  : '<input-pin readonly />',
+  })
+
+  const inputs = screen.queryAllByTestId('input')
+  expect(inputs[0]).toHaveAttribute('readonly')
+})
+
+it('should have readonly attribute if prop readonly was provided', () => {
+  const screen = render({
+    components: { InputPin },
+    template  : '<input-pin readonly />',
+  })
+
+  const inputs = screen.queryAllByTestId('input')
+  expect(inputs[0]).toHaveAttribute('readonly')
+})
+
+it('should failed to typing if input have readonly properties', async () => {
+  const model  = ref('')
+  const screen = render({
+    components: { InputPin },
+    template  : '<input-pin readonly v-model="model"/>',
+  })
+
+  const inputs = screen.queryAllByTestId('input')
+  const user   = userEvent.setup()
+
+  await user.type(inputs.at(1), '1')
+  await user.type(inputs.at(2), '1')
+  await user.type(inputs.at(3), '2')
+  await user.type(inputs.at(4), '3')
+
+  expect(model.value).toBe('')
+})
+
+it('should failed to typing if input have disabled properties', async () => {
+  const model  = ref('')
+  const screen = render({
+    components: { InputPin },
+    template  : '<input-pin disabled v-model="model"/>',
+  })
+
+  const inputs = screen.queryAllByTestId('input')
+  const user   = userEvent.setup()
+
+  await user.type(inputs.at(1), '1')
+  await user.type(inputs.at(2), '1')
+  await user.type(inputs.at(3), '2')
+  await user.type(inputs.at(4), '3')
+
+  expect(model.value).toBe('')
+})

--- a/src/components/input-pin/InputPin.vue
+++ b/src/components/input-pin/InputPin.vue
@@ -142,6 +142,7 @@ export default defineComponent({
 
     function onKeyDown (event: KeyboardEvent) {
       const target = event.target as HTMLInputElement
+      if (props.readonly || props.disabled) return
 
       if (target.value && [...event.key].length === 1 && !event.ctrlKey && !event.metaKey) {
         event.preventDefault()


### PR DESCRIPTION
Hi, creator!

I hope you're well! I've created this pull request to fix an issue in the Input Pin component read-only state, so the cursor is running well, it didn't show up, but when I click to focus on input and try to type some word, it still works, maybe it just because the @keydown event ignores the read-only properties. So I make some guard to ignore the function onKeyDown if the component has read-only/disabled props.  

[https://ibb.co/7g3xnPZ](url)

Please review this pull request when you have time. Your feedback is valuable, and I'm open to making any necessary adjustments.

Thank you!

Best regards,
Rendy Andika