### PR TITLE
fix: update textarea docs

### DIFF
--- a/src/components/textarea/index.md
+++ b/src/components/textarea/index.md
@@ -139,7 +139,7 @@ You can filter what characters are allowed to be input using the prop `accept`. 
 Textarea value can be binding with `v-model`.
 
 <preview>
-  <p-textarea v-model="result" accept="num" />
+  <p-textarea v-model="result" />
 </preview>
 
 **result:**


### PR DESCRIPTION
Hi, creator!
I try to fix the Textarea component documentation, in the section Binding v-model, we can't type anything except numbers, where the docs did not set the accept properties, but in the back maybe you forgot to remove the accept properties.

Changes:
- remove accept properties

Thank you.