### PR TITLE
fix(nav-item): fix nav-item should be using router-link instead anchor tag

### DIFF
--- a/src/components/button/Button.spec.ts
+++ b/src/components/button/Button.spec.ts
@@ -136,7 +136,39 @@ it('should be an anchor when button have `href` props', async () => {
 
   const button = screen.queryByTestId('btn')
 
-  expect(button).toHaveAttribute('href')
+  expect(button).toHaveAttribute('href', '#')
+  expect(button).toContainHTML('a')
+})
+
+it('should be an router-link when button have `href` props without http', async () => {
+  const screen = render({
+    components: { Button },
+    template  : `
+      <Button href="/">
+        Hello
+      </Button>
+    `,
+  })
+
+  const button = screen.queryByTestId('btn')
+
+  expect(button).toHaveAttribute('to', '/')
+  expect(button).toContainHTML('router-link')
+})
+
+it('should be an anchor when button have `href` props and with http', async () => {
+  const screen = render({
+    components: { Button },
+    template  : `
+      <Button href="https://privy.id">
+        Hello
+      </Button>
+    `,
+  })
+
+  const button = screen.queryByTestId('btn')
+
+  expect(button).toHaveAttribute('href', 'https://privy.id')
   expect(button).toContainHTML('a')
 })
 

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,7 +1,8 @@
 <template>
   <component
     :is="tagName"
-    :href="href"
+    :href="tagName === 'a' ? href : undefined"
+    :to="tagName === 'a' ? undefined : href"
     data-testid="btn"
     :class="classNames">
     <slot />
@@ -14,7 +15,10 @@ import {
   defineComponent,
   PropType,
   inject,
+  resolveComponent,
+  type DefineComponent,
 } from 'vue-demi'
+import type { RouteLocationRaw } from 'vue-router'
 
 import {
   ColorVariant,
@@ -49,7 +53,7 @@ export default defineComponent({
       default: false,
     },
     href: {
-      type   : String,
+      type   : [String, Object] as PropType<string | RouteLocationRaw>,
       default: undefined,
     },
   },
@@ -85,13 +89,18 @@ export default defineComponent({
       return result
     })
 
-    const tagName = computed(() => {
-      let tag: TagVariant = 'button'
+    const tagName = computed<TagVariant | DefineComponent>(() => {
+      if (props.href) {
+        if (
+          typeof props.href === 'string'
+          && (props.href.startsWith('http') || props.href.startsWith('#'))
+        )
+          return 'a'
 
-      if (props.href)
-        tag = 'a'
+        return resolveComponent('router-link') as DefineComponent
+      }
 
-      return tag
+      return 'button'
     })
 
     return { classNames, tagName }

--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -279,15 +279,15 @@ Button use local CSS variables on `.btn` for enhanced real-time customization.
 
 ### Props
 
-| Props      |   Type    |  Default  | Description                                                                                                 |
-|------------|:---------:|:---------:|-------------------------------------------------------------------------------------------------------------|
-| `variant`  | `String`  |  `solid`  | Button style variant, valid value is `solid`, `outline`, `ghost` and `link`                                    |
-| `color`    | `String`  | `-`       | Button color variant, valid value is `primary`, `info`, `success`, `warning` and `danger` |
-| `size`     | `String`  |   `md`    | Size of button, valid value is `xs`, `sm`, `md`, `lg`                                                             |
-| `pill`     | `Boolean` |  `false`  | Enable pill mode                                                                                            |
-| `icon`     | `Boolean` |  `false`  | Enable icon mode                                                                                            |
-| `disabled` | `Boolean` |  `false`  | Disable state                                                                                               |
-| `href` | `String` |  `-`  | Place url in the button to make button-like permalink |
+| Props      |   Type                         |  Default  | Description                                                                                                 |
+|------------|:------------------------------:|:---------:|-------------------------------------------------------------------------------------------------------------|
+| `variant`  | `String`                       |  `solid`  | Button style variant, valid value is `solid`, `outline`, `ghost` and `link`                                 |
+| `color`    | `String`                       | `-`       | Button color variant, valid value is `primary`, `info`, `success`, `warning` and `danger`                   |
+| `size`     | `String`                       |   `md`    | Size of button, valid value is `xs`, `sm`, `md`, `lg`                                                       |
+| `pill`     | `Boolean`                      |  `false`  | Enable pill mode                                                                                            |
+| `icon`     | `Boolean`                      |  `false`  | Enable icon mode                                                                                            |
+| `disabled` | `Boolean`                      |  `false`  | Disable state                                                                                               |
+| `href`     | `String` or `RouteLocationRaw` |  `-`      | Place url in the button to make button-like permalink                                                       |
 
 ### Slots
 

--- a/src/components/nav/NavItem.spec.ts
+++ b/src/components/nav/NavItem.spec.ts
@@ -124,3 +124,20 @@ it('should be able to add link class via props `link-class`', () => {
 
   expect(navLink).toHaveClass('link-class')
 })
+
+it('should be using router-link if url without http', () => {
+  const screen = render({
+    components: { Nav, NavItem },
+    template  : `
+      <Nav>
+        <NavItem href="/">link</NavItem>
+      </Nav>
+    `,
+  })
+
+  const navLink = screen.queryByTestId('nav-link')
+
+  expect(navLink).toBeInTheDocument()
+  expect(navLink).toContainHTML('router-link')
+  expect(navLink).toHaveAttribute('to', '/')
+})

--- a/src/components/nav/NavItem.vue
+++ b/src/components/nav/NavItem.vue
@@ -3,9 +3,11 @@
     data-testid="nav-item"
     class="nav__item"
     :class="navItemClass">
-    <a
+    <component
+      :is="tagName"
       data-testid="nav-link"
-      :href="link"
+      :href="isExternalLink ? link : undefined"
+      :to="isExternalLink ? undefined : href"
       :target="target"
       :class="[classNames, linkClass]">
       <span
@@ -20,7 +22,7 @@
         class="nav__link__label">
         <slot />
       </span>
-    </a>
+    </component>
   </li>
 </template>
 
@@ -30,7 +32,9 @@ import {
   computed,
   defineComponent,
   PropType,
+  resolveComponent,
 } from 'vue-demi'
+import { type RouteLocationRaw } from 'vue-router'
 
 export default defineComponent({
   props: {
@@ -43,7 +47,7 @@ export default defineComponent({
       default: false,
     },
     href: {
-      type   : String,
+      type   : [String, Object] as PropType<string | RouteLocationRaw>,
       default: undefined,
     },
     target: {
@@ -97,10 +101,26 @@ export default defineComponent({
       return permalink
     })
 
+    const isExternalLink = computed(() => {
+      return (
+        !props.href
+        || (typeof props.href === 'string'
+          && (props.href.startsWith('http') || props.href.startsWith('#')))
+      )
+    })
+
+    const tagName = computed(() => {
+      if (isExternalLink.value) return 'a'
+
+      return resolveComponent('router-link')
+    })
+
     return {
       classNames,
       navItemClass,
       link,
+      isExternalLink,
+      tagName,
     }
   },
 })

--- a/src/components/nav/index.md
+++ b/src/components/nav/index.md
@@ -551,12 +551,12 @@ If we need some action in section title, you can add this by using `title-action
 
 ### Props `<p-nav-item>`
 
-| Props          |   Type     | Default      | Description                                  |
-|----------------|:----------:|:------------:|-------------------------------------------------------------------|
-| `active`       | `Boolean`  | `false`      | Place component in the active state with active styling           |
-| `disabled`     | `Boolean`  | `false`      | Disables component functionality and place it in disabled state   |
-| `href`         | `String`   | `undefined`  | Target URL of the link                                            |
-| `target`       | `String`   | `_self`      | Sets the `target` attribute on the rendered link, valid value is `_blank`, `_self`, `_parent`, dan `_top` |
+| Props          |   Type                         | Default      | Description                                                                                               |
+|----------------|:------------------------------:|:------------:|-----------------------------------------------------------------------------------------------------------|
+| `active`       | `Boolean`                      | `false`      | Place component in the active state with active styling                                                   |
+| `disabled`     | `Boolean`                      | `false`      | Disables component functionality and place it in disabled state                                           |
+| `href`         | `String` or `RouteLocationRaw` | `undefined`  | Target URL of the link                                                                                    |
+| `target`       | `String`                       | `_self`      | Sets the `target` attribute on the rendered link, valid value is `_blank`, `_self`, `_parent`, dan `_top` |
 
 ### Slots `<p-nav-item>`
 


### PR DESCRIPTION
I've created this pull request to fix the issue with links on the website. Currently, the links  are using anchor tags (<a>) which cause a full page reload when clicked. This can be quite slow and interrupts the smooth user experience.

In this PR, I have replaced the anchor tags with the Vue.js `<router-link>` component. This will ensure that all internal links will be handled by Vue Router, preventing a full page reload and providing a more seamless navigation experience.

Changes Made:
- Replaced anchor tags with `<router-link>` component for all internal links.
- Added conditional check to use `<router-link>` for links without 'http' prefix.

Thank you!
