### PR TITLE
docs: fix typo wording in calendar `binding v-model`

### DIFF
--- a/src/components/calendar/index.md
+++ b/src/components/calendar/index.md
@@ -174,7 +174,7 @@ You can combine multiple format in single value:
 
 ```vue
 <template>
-  <p-calendar v-vmodel="value" />
+  <p-calendar v-model="value" />
 </template>
 ```
 


### PR DESCRIPTION
Hi creator,
I've made a few changes in your documentation, please review my pull request.

changelog: 
- fix the typo in the docs calendar component

Thanks