### PR TITLE
docs: fix custom appearance behaviour

### DIFF
--- a/src/components/checkbox/index.md
+++ b/src/components/checkbox/index.md
@@ -16,6 +16,7 @@ description: Base checkbox form
   const modelA   = ref(false)
   const modelB   = ref('disagree')
   const selected = ref([])
+  const selected2= ref([])
 
   const items  = ref(['apple', 'grape', 'orange'])
   const result = ref(['apple'])
@@ -244,7 +245,7 @@ It's possible to create checkbox with custom appearance. If don't wanna see "che
 
 <preview class="justify-center">
   <div class="flex flex-col space-y-3">
-    <p-checkbox appearance="none" v-model="selected" value="Olivia Withness">
+    <p-checkbox appearance="none" v-model="selected2" value="Olivia Withness">
       <template #default>
         <p-card
           element="div"
@@ -260,7 +261,7 @@ It's possible to create checkbox with custom appearance. If don't wanna see "che
         </p-card>
       </template>
     </p-checkbox>
-    <p-checkbox appearance="none" v-model="selected" value="Hyuga Kojiro">
+    <p-checkbox appearance="none" v-model="selected2" value="Hyuga Kojiro">
       <template #default>
         <p-card
           element="div"
@@ -276,7 +277,7 @@ It's possible to create checkbox with custom appearance. If don't wanna see "che
         </p-card>
       </template>
     </p-checkbox>
-    <p-checkbox appearance="none" v-model="selected" value="Marsha Timoty" disabled>
+    <p-checkbox appearance="none" v-model="selected2" value="Marsha Timoty" disabled>
       <template #default>
         <p-card
           element="div"
@@ -297,7 +298,7 @@ It's possible to create checkbox with custom appearance. If don't wanna see "che
 
 **Selected :**
 
-<pre><code>{{ selected }}</code></pre>
+<pre><code>{{ selected2 }}</code></pre>
 
 ```vue
 <template>


### PR DESCRIPTION
Hi creator!

I've made a few changes in the checkbox documentation, I've found that the component checkbox in section `binding v-model -> array v-model` use the same v-model value as the component checkbox in section `custom-appearance`, so it will make some people confusing when playing in the docs playground, maybe it will helpful to make the docs more understandable.

changelog:
- make a new data model for the custom appearance component

Thanks