### PR TITLE
feat: set default type properties in button

### DIFF
--- a/src/components/button/Button.spec.ts
+++ b/src/components/button/Button.spec.ts
@@ -205,3 +205,17 @@ it('should automatically set size of button via `size` props of input-group', ()
   expect(inputGroup).toBeInTheDocument()
   expect(button).toHaveClass('btn--sm')
 })
+
+it('should have type properties with value button if the element is button', () => {
+  const screen = render({
+    components: { Button },
+    template  : `
+        <Button >Text</Button>
+    `,
+  })
+
+  const button = screen.queryByTestId('btn')
+
+  expect(button).toBeInTheDocument()
+  expect(button).toHaveProperty('type', 'button')
+})

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -3,6 +3,7 @@
     :is="tagName"
     :href="tagName === 'a' ? href : undefined"
     :to="tagName === 'a' ? undefined : href"
+    :type="tagName === 'a' ? undefined : type"
     data-testid="btn"
     :class="classNames">
     <slot />
@@ -25,6 +26,7 @@ import {
   SizeVariant,
   StyleVariant,
   TagVariant,
+  TypeVariant,
 } from '.'
 import { BUTTONGROUP_SETTING } from '../button-group'
 
@@ -55,6 +57,10 @@ export default defineComponent({
     href: {
       type   : [String, Object] as PropType<string | RouteLocationRaw>,
       default: undefined,
+    },
+    type: {
+      type   : String as PropType<TypeVariant>,
+      default: 'button',
     },
   },
   setup (props) {

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -5,3 +5,5 @@ export type ColorVariant = 'default' | 'primary' | 'info' | 'success' | 'warning
 export type SizeVariant = 'xs' | 'sm' | 'md' | 'lg'
 
 export type TagVariant = 'a' | 'button'
+
+export type TypeVariant = 'button' | 'menu' | 'reset' | 'submit'


### PR DESCRIPTION
Hi creator,

I hope you're well! I've created this pull request to add a type in the Button component because I think that's important to set the default type in the component button implicitly because we don't know the behavior of the component. Sometimes I found in others' Persona component that using p-button have weird behavior like it always re-renders the component, like the type submit behavior, so it will be nice if we set the default type.

Changes:
- Add the default type of button with the value 'button'

Testing:
I've performed thorough testing to ensure the new functionality works as expected:
- Make sure that the component button has the type button.
Notes:
I've updated the codebase documentation and comments to reflect the changes accurately.

Please review this pull request when you have time. Your feedback is valuable, and I'm open to making any necessary adjustments.

Thank you!

Best regards,
Rendy Andika