### PR TITLE
feat: add ability to clear select state with clearable props

### DIFF
--- a/src/components/select/Select.spec.ts
+++ b/src/components/select/Select.spec.ts
@@ -358,3 +358,19 @@ it('should hide caret icon if props `no-caret` is provided', () => {
 
   expect(caret).not.toBeInTheDocument()
 })
+
+it('should have a clear button when `clearable` props is provided', async () => {
+  const screen = render({
+    components: { Select },
+    template  : `
+      <Select clearable />
+    `,
+  })
+  const select = screen.getByTestId('select')
+  expect(select).toBeInTheDocument()
+
+  await fireEvent.click(select)
+
+  const clearButton = screen.queryByTestId('input-clear')
+  expect(clearButton).toBeInTheDocument()
+})

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -15,6 +15,7 @@
         :placeholder="placeholder"
         :disabled="disabled"
         :readonly="readonly"
+        :clearable="clearable"
         @focus="onFocus">
         <template
           v-if="!noCaret"
@@ -172,6 +173,10 @@ export default defineComponent({
       default: false,
     },
     error: {
+      type   : Boolean,
+      default: false,
+    },
+    clearable: {
       type   : Boolean,
       default: false,
     },

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -128,6 +128,29 @@ description: Base form input.
   ])
 </script>
 ```
+
+### with Clearable
+
+<preview>
+  <p-select :options="optionsB" v-model="value" clearable/>
+</preview>
+
+```vue
+<template>
+  <p-select
+    v-model="value"
+    :options="options"
+    clearable />
+</template>
+
+<script setup>
+  const options = ref([
+    { text: '🍎 Apfel', value: 'Apple' },
+    { text: '🍇 Traube', value: 'Grape' },
+    { text: '🍌 Bananen', value: 'Banana'},
+  ])
+</script>
+```
 ## Placeholder
 
 You can set input placeholder via `placeholder` props
@@ -152,8 +175,8 @@ You can set sectiom label via `section-label` props
 
 ```vue
 <template>
-  <p-select placeholder="Pick A Value" 
-    :options="optionsA" 
+  <p-select placeholder="Pick A Value"
+    :options="optionsA"
     section-label="Fruits" />
 </template>
 ```


### PR DESCRIPTION
Hi creator,

I hope you're well! I've created this pull request to add clearable props in the Select component, the purpose is to give developers an option to make their select component have the ability to clear the state.

Changes:
- Add props clearable to show the clear button

Testing:
I've performed thorough testing to ensure the new functionality works as expected:

Notes:
I've updated the codebase documentation and comments to reflect the changes accurately.
Please review this pull request when you have time. Your feedback is valuable, and I'm open to making any necessary adjustments.

Thank you!

Best regards,
Rendy Andika