### PR TITLE
feat(dialog): adding options dialog for dismiss and no close dialog

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -6,6 +6,8 @@
     :title="context.title"
     :size="context.size"
     :centered="context.centered"
+    :dismissable="context.dismissable"
+    :no-close-on-backdrop="context.noCloseOnBackdrop"
     :text="context.text"
     @close="onCancel">
     <template #footer>

--- a/src/components/dialog/index.md
+++ b/src/components/dialog/index.md
@@ -80,15 +80,17 @@ dialog.confirm({
 
 `confirm(options: DialogOptions): Promise<boolean>`
 
-| Options       |   Type   | Default  | Description                                                               |
-|---------------|:--------:|:--------:|---------------------------------------------------------------------------|
-| `title`       | `String` |    -     | Dialog title, **required**                                                |
-| `text`        | `String` |    -     | Dialog text content                                                       |
-| `size`        | `String` |    -     | Dialog size, valid value is `sm`, `md`, `lg`, `xl`                        |
-| `centered`    | `Boolean`|  `false`   | Dialog vertically center in the viewport                                  |
-| `footerAlign` | `Number` |  `start` | The alignment of dialog footer, valid value is `start` and `end`          |
-| `cancel`      | `DialogButton` |    -     | Cancel button's options for dialog footer                           |
-| `confirm`     | `DialogButton` |    -     | Confirm button's options for dialog footer                          |
+| Options             |   Type   | Default  | Description                                                                     |
+|---------------------|:--------------:|:--------:|---------------------------------------------------------------------------|
+| `title`             | `String`       |    -     | Dialog title, **required**                                                |
+| `text`              | `String`       |    -     | Dialog text content                                                       |
+| `size`              | `String`       |    -     | Dialog size, valid value is `sm`, `md`, `lg`, `xl`                        |
+| `centered`          | `Boolean`      | `false`  | Dialog vertically center in the viewport                                  |
+| `dismissable`       | `Boolean`      | `true`   | Show / Hide dismiss button                                                |
+| `noCloseOnBackdrop` | `Boolean`      | `false`  | No close dialog while dialog Backdrop was clicked                         |
+| `footerAlign`       | `Number`       | `start`  | The alignment of dialog footer, valid value is `start` and `end`          |
+| `cancel`            | `DialogButton` |    -     | Cancel button's options for dialog footer                                 |
+| `confirm`           | `DialogButton` |    -     | Confirm button's options for dialog footer                                |
 
 `DialogButton`
 

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -20,6 +20,8 @@ export interface DialogOptions {
   text?: string,
   size?: SizeVariant,
   centered?: boolean,
+  dismissable?: boolean,
+  noCloseOnBackdrop?: boolean,
   footerAlign?: FooterAlignVariant,
   cancel?: DialogButton,
   confirm?: DialogButton,


### PR DESCRIPTION
Adding setup or options in dialog for:
- hide close button
- no close modal on backdrop