### PR TITLE
fix(select): fix selected values when option items updated after search

### DIFF
--- a/src/components/select/Select.spec.ts
+++ b/src/components/select/Select.spec.ts
@@ -476,7 +476,7 @@ it('should have clear button if prop `clearable` was provided', async () => {
 
   await fireEvent.click(clear)
 
-  expect(model.value).toBeUndefined()
+  expect(model.value).toStrictEqual({ text: '', value: undefined })
 })
 
 it('should clear search keyword if click clear button when select was opened', async () => {
@@ -594,4 +594,41 @@ it('should show selected items when options updated', async () => {
   await nextTick()
 
   expect(activator).toHaveTextContent('orange')
+})
+
+it('should be keep selected when option changed after search', async () => {
+  const options = ref<string[]>([
+    'apple',
+    'grape',
+    'orange',
+  ])
+  const model   = ref('apple')
+  const screen  = render({
+    components: { Select },
+    template  : `
+      <Select
+        v-model="model"
+        :options="options"
+      />
+    `,
+    setup () {
+      return { model, options }
+    },
+  })
+
+  const activator = screen.queryByTestId('select-activator')
+
+  expect(activator).toHaveTextContent('apple')
+
+  const select = screen.queryByTestId('select')
+  const caret  = screen.queryByTestId('select-caret-icon')
+
+  await fireEvent.click(caret)
+
+  expect(select).toHaveClass('select--open')
+
+  await fireEvent.update(screen.queryByTestId('select-search'), 'orange')
+  await nextTick()
+
+  expect(activator).toHaveTextContent('apple')
 })

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -51,6 +51,7 @@ description: Base form input.
   const province   = ref('')
   const city       = ref('')
   const multiValue = ref([])
+  const provinces  = ref([])
 
   const provincesAdapter = defineAsyncAdapter(async (keyword, page, perPage) => {
     const response = await getProvinces(keyword, page, perPage)
@@ -258,6 +259,10 @@ You can set size of select via `size` prop. Available size are `lg`, `md`, `sm`,
   <p-select :options="optionsD" v-model="multiValue" multiple />
 </preview>
 
+**Result :**
+
+<pre><code>{{ multiValue || [] }}</code></pre>
+
 ```vue
 <template>
   <p-select :options="optionsD" v-model="multiValue" multiple />
@@ -360,11 +365,24 @@ It will take care of loading, inifinite load, and other stuff.
 
 <pre><code>{{ province }}</code></pre>
 
+### Multiple value
+<preview>
+  <p-select
+    :adapter="provincesAdapter"
+    v-model="provinces"
+    multiple />
+</preview>
+
+**Result:**
+
+<pre><code>{{ provinces }}</code></pre>
+
 ```vue
 <template>
   <p-select
     :adapter="provincesAdapter"
-    v-model="province" />
+    v-model="province"
+    multiple />
 </template>
 
 <script setup>


### PR DESCRIPTION
When current select have a value, then option updated after searching, current selected will gone if current value not in options items.
cases that occur frequently is on options with asyncronous adapter.