### PR TITLE
feat(pdf-worker): add option to use local PDF.js worker

### DIFF
--- a/packages/persona/src/runtime/plugin.ts
+++ b/packages/persona/src/runtime/plugin.ts
@@ -5,22 +5,25 @@ import {
   installRouter,
 } from '@privyid/persona/core'
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const router = useRouter()
-  const store  = initStore()
+export default defineNuxtPlugin({
+  name : 'persona-setup',
+  setup: (nuxtApp) => {
+    const router = useRouter()
+    const store  = initStore()
 
-  installRouter({
-    getURL () {
-      return router.currentRoute.value.fullPath
-    },
-    async toURL (url: string) {
-      return await router.push(url)
-    },
-  })
+    installRouter({
+      getURL () {
+        return router.currentRoute.value.fullPath
+      },
+      async toURL (url: string) {
+        return await router.push(url)
+      },
+    })
 
-  // SSR Store & Hydrate
-  if (process.server)
-    nuxtApp.payload.persona = store.value
-  else if (nuxtApp.payload?.persona)
-    store.value = nuxtApp.payload.persona as State
+    // SSR Store & Hydrate
+    if (process.server)
+      nuxtApp.payload.persona = store.value
+    else if (nuxtApp.payload?.persona)
+      store.value = nuxtApp.payload.persona as State
+  },
 })


### PR DESCRIPTION
This PR introduces a new configuration option, `useLocalPdfWorker`, to enable or disable the use of a local PDF.js worker

### Usage
nuxt.config.ts
```ts
persona: {
   useLocalPdfWorker: true
}
```